### PR TITLE
Improve memory allocation.

### DIFF
--- a/src/test/java/org/anarres/parallelgzip/ParallelGZIPOutputStreamTest.java
+++ b/src/test/java/org/anarres/parallelgzip/ParallelGZIPOutputStreamTest.java
@@ -14,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +29,7 @@ public class ParallelGZIPOutputStreamTest {
 
     private static class ByteArrayOutputBuffer extends ByteArrayOutputStream {
 
-        public ByteArrayOutputBuffer(int size) {
+        public ByteArrayOutputBuffer(@Nonnegative int size) {
             super(size);
         }
 


### PR DESCRIPTION
@simlu Let's talk this over on a PR.

Outstanding questions are:
* Is card-marking causing semispace collections rather than just eden space collections? Did you happen to note?
* How do we control resource allocation in the free-list?

I just had an idea: In steady state, the execution queue has about 3 blocks per thread. The size of the free-list is bounded by the size of the execution queue; there's no point bounding it separately. However, this remains a heuristic optimization. So if we assume that the system is being fed in steady state, then we approximate one emit per submit. This means in turn that the free block list can just be a single free block pointer, and this resolves my concern that a stream which has lumpy service requests will hold onto 2Mb of memory for no special reason. In fact, if we look at `submit()`, it's fairly clear that the call to emitUntil or tryEmit() will mostly return the single free block that the next call "wants".

I'm still mostly interested in this as a performance optimization, either due to GC overhead or straight-up performance.